### PR TITLE
Change drop location of clair binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,10 @@ RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh && 
 
 FROM alpine
 
-COPY --from=0 /gopath/src/clair/clair .
+COPY --from=0 /gopath/src/clair/clair /usr/local/bin
 
 EXPOSE 9279
 
-ENTRYPOINT ["./clair"]
+ENTRYPOINT ["clair"]
 
 CMD []


### PR DESCRIPTION
Using your image inside jenkins gives and error because the working directory is changed and the entrypoint ./clair is no longer valid. This puts the clair in a more standard location available in the path